### PR TITLE
Add 4 test to improve test coverage

### DIFF
--- a/cli/compose/convert/volume_test.go
+++ b/cli/compose/convert/volume_test.go
@@ -104,6 +104,18 @@ func TestConvertVolumeToMountConflictingOptionsTmpfsInBind(t *testing.T) {
 	assert.Error(t, err, "tmpfs options are incompatible with type bind")
 }
 
+func TestConvertVolumeToMountConflictingOptionsClusterInVolume(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "volume",
+		Target: "/target",
+		Cluster: &composetypes.ServiceVolumeCluster{},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "cluster options are incompatible with type volume")
+}
+
 func TestConvertVolumeToMountConflictingOptionsBindInTmpfs(t *testing.T) {
 	namespace := NewNamespace("foo")
 

--- a/cli/compose/convert/volume_test.go
+++ b/cli/compose/convert/volume_test.go
@@ -132,6 +132,21 @@ func TestConvertVolumeToMountConflictingOptionsClusterInBind(t *testing.T) {
 	assert.Error(t, err, "cluster options are incompatible with type bind")
 }
 
+func TestConvertVolumeToMountConflictingOptionsClusterInTmpfs(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "tmpfs",
+		Target: "/target",
+		Tmpfs: &composetypes.ServiceVolumeTmpfs{
+			Size: 1000,
+		},
+		Cluster: &composetypes.ServiceVolumeCluster{},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "cluster options are incompatible with type tmpfs")
+}
+
 func TestConvertVolumeToMountConflictingOptionsBindInTmpfs(t *testing.T) {
 	namespace := NewNamespace("foo")
 

--- a/cli/compose/convert/volume_test.go
+++ b/cli/compose/convert/volume_test.go
@@ -116,6 +116,22 @@ func TestConvertVolumeToMountConflictingOptionsClusterInVolume(t *testing.T) {
 	assert.Error(t, err, "cluster options are incompatible with type volume")
 }
 
+func TestConvertVolumeToMountConflictingOptionsClusterInBind(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "bind",
+		Source: "/foo",
+		Target: "/target",
+		Bind: &composetypes.ServiceVolumeBind{
+			Propagation: "slave",
+		},
+		Cluster: &composetypes.ServiceVolumeCluster{},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "cluster options are incompatible with type bind")
+}
+
 func TestConvertVolumeToMountConflictingOptionsBindInTmpfs(t *testing.T) {
 	namespace := NewNamespace("foo")
 

--- a/cli/compose/template/template_test.go
+++ b/cli/compose/template/template_test.go
@@ -220,7 +220,7 @@ func TestExtractVariables(t *testing.T) {
 		{
 			name: "required-variable",
 			dict: map[string]any{
-				"foo": "${bar?:foo}",
+				"foo": "${bar:?foo}",
 			},
 			expected: map[string]string{
 				"bar": "",


### PR DESCRIPTION
Added 4 tests to improve the test coverage

- 3 tests in file `cli/compose/convert/volume_test.go`
- 1 test in file `cli/compose/template/template_test.go`

closes #6 