### PR TITLE
Improve cluster test coverage in volume.go

### DIFF
--- a/cli/compose/convert/volume_test.go
+++ b/cli/compose/convert/volume_test.go
@@ -499,3 +499,18 @@ func TestHandleClusterToMountConflictingOptionsTmpfsInCluster(t *testing.T) {
 	_, err := convertVolumeToMount(config, volumes{}, namespace)
 	assert.Error(t, err, "tmpfs options are incompatible with type cluster")
 }
+
+func TestHandleClusterToMountConflictingOptionsVolumeInCluster(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "cluster",
+		Source: "/foo",
+		Target: "/target",
+		Volume: &composetypes.ServiceVolumeVolume{
+			NoCopy: true,
+		},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "volume options are incompatible with type cluster")
+}

--- a/cli/compose/convert/volume_test.go
+++ b/cli/compose/convert/volume_test.go
@@ -514,3 +514,16 @@ func TestHandleClusterToMountConflictingOptionsVolumeInCluster(t *testing.T) {
 	_, err := convertVolumeToMount(config, volumes{}, namespace)
 	assert.Error(t, err, "volume options are incompatible with type cluster")
 }
+
+func TestHandleClusterToMountBind(t *testing.T) {
+	namespace := NewNamespace("foo")
+	config := composetypes.ServiceVolumeConfig{
+		Type:     "cluster",
+		Source:   "/bar",
+		Target:   "/foo",
+		ReadOnly: true,
+		Bind:     &composetypes.ServiceVolumeBind{Propagation: "shared"},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "bind options are incompatible with type cluster")
+}

--- a/cli/compose/convert/volume_test.go
+++ b/cli/compose/convert/volume_test.go
@@ -470,3 +470,17 @@ func TestConvertVolumeMountClusterGroup(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Check(t, is.DeepEqual(expected, mnt))
 }
+
+func TestHandleClusterToMountAnonymousCluster(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "cluster",
+		Target: "/target",
+		Volume: &composetypes.ServiceVolumeVolume{
+			NoCopy: true,
+		},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "invalid cluster source, source cannot be empty")
+}

--- a/cli/compose/convert/volume_test.go
+++ b/cli/compose/convert/volume_test.go
@@ -484,3 +484,18 @@ func TestHandleClusterToMountAnonymousCluster(t *testing.T) {
 	_, err := convertVolumeToMount(config, volumes{}, namespace)
 	assert.Error(t, err, "invalid cluster source, source cannot be empty")
 }
+
+func TestHandleClusterToMountConflictingOptionsTmpfsInCluster(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "cluster",
+		Source: "/foo",
+		Target: "/target",
+		Tmpfs: &composetypes.ServiceVolumeTmpfs{
+			Size: 1000,
+		},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "tmpfs options are incompatible with type cluster")
+}


### PR DESCRIPTION
Adds 4 tests to the ```cli/compose/convert/volume_test.go``` file.
All tests relate to cluster mounting.

Thanks to @asirago for advice where test coverage can be increased and @Lussebullen since his test cases are in the same file and have a similar structure.

closes #13 