### PR TITLE
Add 5 unit tests for code coverage

### DIFF
--- a/cli/command/utils_test.go
+++ b/cli/command/utils_test.go
@@ -68,3 +68,11 @@ func TestValidateOutputPath(t *testing.T) {
 		})
 	}
 }
+
+func TestCapitalizeFirstReturnsEmptyStringIfGivenEmptyString(t *testing.T) {
+	assert.Equal(t, capitalizeFirst(""), "")
+}
+
+func TestCapitalizeFirstReturnsStringWithUppercaseFirstLetterIfItWasLowercase(t *testing.T) {
+	assert.Equal(t, capitalizeFirst("blahonga"), "Blahonga")
+}

--- a/cli/compose/convert/compose_test.go
+++ b/cli/compose/convert/compose_test.go
@@ -16,6 +16,16 @@ func TestNamespaceScope(t *testing.T) {
 	assert.Check(t, is.Equal("foo_bar", scoped))
 }
 
+func TestNamespaceDescope(t *testing.T) {
+	descoped := Namespace{name: "foo"}.Descope("foo_bar")
+	assert.Check(t, is.Equal("bar", descoped))
+}
+
+func TestNamespaceName(t *testing.T) {
+	namespaceName := Namespace{name: "foo"}.Name()
+	assert.Check(t, is.Equal("foo", namespaceName))
+}
+
 func TestAddStackLabel(t *testing.T) {
 	labels := map[string]string{
 		"something": "labeled",

--- a/cli/compose/convert/service_test.go
+++ b/cli/compose/convert/service_test.go
@@ -61,6 +61,15 @@ func TestConvertEnvironment(t *testing.T) {
 	assert.Check(t, is.DeepEqual([]string{"foo=bar", "key=value"}, env))
 }
 
+func TestConvertEnvironmentWhenNilValueExists(t *testing.T) {
+	source := map[string]*string{
+		"key":            strPtr("value"),
+		"keyWithNoValue": nil,
+	}
+	env := convertEnvironment(source)
+	assert.Check(t, is.DeepEqual([]string{"key=value", "keyWithNoValue"}, env))
+}
+
 func TestConvertExtraHosts(t *testing.T) {
 	source := composetypes.HostsList{
 		"zulu:127.0.0.2",


### PR DESCRIPTION
Add 5 unit test for additional code coverage. 

* In `github.com/docker/cli/cli/compose/convert/compose.go`:
  * Add unit test for method function `Descope()`.
  * Add unit test for method function `Name()`.
  * Coverage difference in source file: 78.9% -> 81.7%

* In `github.com/docker/cli/cli/compose/service.go`:
  * Add unit test for function `convertEnvironment()` to cover `case nil` in switch statement. 
  * Coverage difference in source file: 79.2% -> 79.6%
  
* In `github.com/docker/cli/cli/command/utils.go`:
  * Add unit test for function `capitalizeFirst()` to cover `case 0` in switch statement.
  * Add unit test for function `capitalizeFirst()` to cover `case default` in switch statement.
  * Coverage difference in source file: 29.8% -> 33.3%

closes #18

Signed-off-by: Omar Askar Vergara <omaraskar@outlook.com>