### PR TITLE
test/ Added test coverage for handleNpipeToMount

### DIFF
--- a/cli/compose/convert/volume_test.go
+++ b/cli/compose/convert/volume_test.go
@@ -132,6 +132,50 @@ func TestConvertVolumeToMountConflictingOptionsVolumeInTmpfs(t *testing.T) {
 	assert.Error(t, err, "volume options are incompatible with type tmpfs")
 }
 
+func TestHandleNpipeToMountAnonymousNpipe(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "npipe",
+		Target: "/target",
+		Volume: &composetypes.ServiceVolumeVolume{
+			NoCopy: true,
+		},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "invalid npipe source, source cannot be empty")
+}
+
+func TestHandleNpipeToMountConflictingOptionsTmpfsInNpipe(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "npipe",
+		Source: "/foo",
+		Target: "/target",
+		Tmpfs: &composetypes.ServiceVolumeTmpfs{
+			Size: 1000,
+		},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "tmpfs options are incompatible with type npipe")
+}
+
+func TestHandleNpipeToMountConflictingOptionsVolumeInNpipe(t *testing.T) {
+	namespace := NewNamespace("foo")
+
+	config := composetypes.ServiceVolumeConfig{
+		Type:   "npipe",
+		Source: "/foo",
+		Target: "/target",
+		Volume: &composetypes.ServiceVolumeVolume{
+			NoCopy: true,
+		},
+	}
+	_, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.Error(t, err, "volume options are incompatible with type npipe")
+}
+
 func TestConvertVolumeToMountNamedVolume(t *testing.T) {
 	stackVolumes := volumes{
 		"normal": composetypes.VolumeConfig{
@@ -342,6 +386,27 @@ func TestConvertTmpfsToMountVolumeWithSource(t *testing.T) {
 
 	_, err := convertVolumeToMount(config, volumes{}, NewNamespace("foo"))
 	assert.Error(t, err, "invalid tmpfs source, source must be empty")
+}
+
+func TestHandleNpipeToMountBind(t *testing.T) {
+	namespace := NewNamespace("foo")
+	expected := mount.Mount{
+		Type:        mount.TypeNamedPipe,
+		Source:      "/bar",
+		Target:      "/foo",
+		ReadOnly:    true,
+		BindOptions: &mount.BindOptions{Propagation: mount.PropagationShared},
+	}
+	config := composetypes.ServiceVolumeConfig{
+		Type:     "npipe",
+		Source:   "/bar",
+		Target:   "/foo",
+		ReadOnly: true,
+		Bind:     &composetypes.ServiceVolumeBind{Propagation: "shared"},
+	}
+	mnt, err := convertVolumeToMount(config, volumes{}, namespace)
+	assert.NilError(t, err)
+	assert.Check(t, is.DeepEqual(expected, mnt))
 }
 
 func TestConvertVolumeToMountAnonymousNpipe(t *testing.T) {


### PR DESCRIPTION
Added tests for complete coverage of handleNpipeToMount.

Code coverage BEFORE:

github.com/docker/cli/cli/compose/convert/volume.go:138.25,140.3 1 0
github.com/docker/cli/cli/compose/convert/volume.go:141.2,141.26 1 1
github.com/docker/cli/cli/compose/convert/volume.go:141.26,143.3 1 0
github.com/docker/cli/cli/compose/convert/volume.go:144.2,144.25 1 1
github.com/docker/cli/cli/compose/convert/volume.go:144.25,146.3 1 0
github.com/docker/cli/cli/compose/convert/volume.go:147.2,147.24 1 1
github.com/docker/cli/cli/compose/convert/volume.go:147.24,151.3 1 0

Code coverage AFTER:

github.com/docker/cli/cli/compose/convert/volume.go:138.25,140.3 1 1
github.com/docker/cli/cli/compose/convert/volume.go:141.2,141.26 1 1
github.com/docker/cli/cli/compose/convert/volume.go:141.26,143.3 1 1
github.com/docker/cli/cli/compose/convert/volume.go:144.2,144.25 1 1
github.com/docker/cli/cli/compose/convert/volume.go:144.25,146.3 1 1
github.com/docker/cli/cli/compose/convert/volume.go:147.2,147.24 1 1
github.com/docker/cli/cli/compose/convert/volume.go:147.24,151.3 1 1

fixes #9 